### PR TITLE
fix/typos in 10_craigslist_ad.html

### DIFF
--- a/2-structure/10_craigslist_ad.html
+++ b/2-structure/10_craigslist_ad.html
@@ -17,7 +17,7 @@
     <p>Australian Aboriginal Didgeridoo. Needs work. Free to good home</p>
 
     <ul>
-      <li>do NOT contact me with unsolicited services or offerse</li>
+      <li>do NOT contact me with unsolicited services or offers</li>
     </ul>
   </body>
 </html>

--- a/2-structure/10_craigslist_ad.html
+++ b/2-structure/10_craigslist_ad.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <!-- This is a level 1 heading. -->
-    <h1> --> Didgeridoo. Needs work. </h1>
+    <h1>Didgeridoo. Needs work. </h1>
 
     <!-- This is an image of a didgeridoo, a musical instrument. -->
     <img src="https://i.imgur.com/TrXO7Sa.png">

--- a/2-structure/10_craigslist_ad.html
+++ b/2-structure/10_craigslist_ad.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <!-- This is a level 1 heading. -->
-    <h1>Didgeridoo. Needs work. </h1>
+    <h1>Didgeridoo. Needs work.</h1>
 
     <!-- This is an image of a didgeridoo, a musical instrument. -->
     <img src="https://i.imgur.com/TrXO7Sa.png">


### PR DESCRIPTION
## PR fix for #12.

### Description

- This PR addresses two typos identified in the provided HTML code:

1. The comment character `-->` within the `<h1>` tag has been removed, fixing the first issue.
2. The typo in the list item within the `<ul>` element has been corrected. The word "offerse" has been changed to "offers."

### Changes Made

1. Removed `-->` from the `<h1>` tag.
2. Corrected the typo in the list item within the `<ul>` element.
3. Removed an extra space at the end of the sentence within `h1` for cleaner code.

### Testing

- I have tested the HTML code after making these changes, and the issues have been resolved. The `<h1>` heading now contains only the text "Didgeridoo. Needs work," and the typo in the list item has been fixed.

### Related Issues:

- This PR closes #12.