### PR TITLE
fix: typo from It to It's

### DIFF
--- a/1-elements/04_corporate.html
+++ b/1-elements/04_corporate.html
@@ -5,7 +5,7 @@
    <p>
      <b>Cutting Down, Ramping Up: </b>
      We have a robust strategy for <s>low-hanging fruits</s> mission-critial objectives that move the needle at all costs. 
-     It time to double down on <b>revenue growth</b> while <u>cutting costs</u>. 
+     It's time to double down on <b>revenue growth</b> while <u>cutting costs</u>. 
      This is a win-win initiative; a win for us and our amazing shareholders!
    </p>
    <p>


### PR DESCRIPTION
# Typo Fix
- This PR fixes a typo in [01-shooting-star](https://github.com/codedex-io/html-101/blob/main/1-elements/04_corporate.html) exercise.

## Changes:
- Corrected `It` to `It's`.

## Expected changes:
- The sentence now correctly displays: `It's time to double down on revenue growth while cutting costs.`

## Related issues:
- This PR closes #14.