### PR TITLE
docs: add .html extension to figures link description

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Welcome to The Origins I: HTML GitHub repo! We are super excited to have you. He
 - [`the_header.html`](https://github.com/codedex-io/html-101/blob/main/4-semantic-html/22_the_header.html)
 - [`main_footer.html`](https://github.com/codedex-io/html-101/blob/main/4-semantic-html/23_main_footer.html)
 - [`blog_posts.html`](https://github.com/codedex-io/html-101/blob/main/4-semantic-html/24_blog_posts.html)
-- [`figures`](https://github.com/codedex-io/html-101/blob/main/4-semantic-html/25_figures.html)
+- [`figures.html`](https://github.com/codedex-io/html-101/blob/main/4-semantic-html/25_figures.html)
 - [`final_touches.html`](https://github.com/codedex-io/html-101/blob/main/4-semantic-html/26_final_touches.html)
 
 ---


### PR DESCRIPTION
# Docs update:
- This PR updates the missing `.html` extension for the `figures` link description.

## Reasons for this change:
- All link descriptions follow a consistency of having the `.html` extension within the description. `figures` not having this created an inconsistency in `README.md`.

## Screenshot of update:
<img width="468" alt="image" src="https://github.com/codedex-io/html-101/assets/140430987/5ae074e1-8587-447c-aeb5-90afadc2e695">

## Related issue:
- This PR closes #20.