### PR TITLE
Proposal of fix to typo in 08_blueprint.html

### DIFF
--- a/2-structure/08_blueprint.html
+++ b/2-structure/08_blueprint.html
@@ -8,7 +8,7 @@
   </head>
   <body>
     <p>
-      Place your paragragh text here.
+      Place your paragraph text here.
     </p>
   </body>
 </html>


### PR DESCRIPTION
Hello team,

I would like to report a typo from this [file](https://github.com/codedex-io/html-101/blob/9676930310ec68b1a24e68371b0afb786842eceb/2-structure/08_blueprint.html).

The string 'paragragh' should be replaced with 'paragraph'.

See attached picture for more context. 👇
![htmlTypoBlueprint](https://github.com/codedex-io/html-101/assets/48260426/dde66ff9-d926-449b-8fcb-ba4d2a893aae)
