### PR TITLE
Fix: Remove unused HTML class in file 14_top_8.html

### DIFF
--- a/2-structure/14_top_8.html
+++ b/2-structure/14_top_8.html
@@ -37,7 +37,7 @@
 <body>
   <div id="top-8-wrapper">
     <h1>My Top 8 Friends!</h1>
-    <div class="top-8-row">
+    <div>
       <div class="friend-card">
         <h3 class="friend-name">My Friend Tom</h3>
         <img src="https://i.imgur.com/IZ3Vf9Nb.jpg" alt="Tom from MySpace">
@@ -59,7 +59,7 @@
       </div>
     </div>
 
-    <div class="top-8-row">
+    <div>
       <div class="friend-card">
         <h3 class="friend-name">My Friend Tom</h3>
         <img src="https://i.imgur.com/IZ3Vf9Nb.jpg" alt="Tom from MySpace">


### PR DESCRIPTION
Hello team,

I would like to propose a fix to a class that is never used in this [file](https://github.com/codedex-io/html-101/blob/main/2-structure/14_top_8.html). 

From a beginner perspective, having a class that is not used in the <style> tag is unnecessary and can cause confusion in understanding the context of the solution.  

### Change

1. Removed two class="top-8-row".

### Alternative solutions

1. Add some CSS parameters to the class "top-8-row".
2. Rename the second class "top-8-row" to "bottom-8-row" and leave them unused, that makes it easier to understand which row has what. 
