### PR TITLE
Fix: missing link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Welcome to The Origins I: HTML GitHub repo! We are super excited to have you. He
 ## <img src="https://www.codedex.io/images/badges/html/elements.png" height="20" style="vertical-align: middle"> Elements
 
 - [`star.html`](https://github.com/codedex-io/html-101/blob/main/1-elements/01_star.html)
+- [`elemental.html`](https://github.com/codedex-io/html-101/blob/main/1-elements/02_elemental.html)
 - [`newspaper.html`](https://github.com/codedex-io/html-101/blob/main/1-elements/03_newspaper.html)
 - [`corporate.html`](https://github.com/codedex-io/html-101/blob/main/1-elements/04_corporate.html)
 - [`chef.html`](https://github.com/codedex-io/html-101/blob/main/1-elements/05_chef.html)


### PR DESCRIPTION
Added link for elemental.html in the readme file because it was missing