### PR TITLE
fix: en dash

### DIFF
--- a/1-elements/05_chef.html
+++ b/1-elements/05_chef.html
@@ -23,7 +23,7 @@
     <li>Beat the butter and the sugar in a large bowl with a mixer until light and fluffy.</li>
     <li>Beat in the eggs, vanilla, and flour, slowly, until smooth.</li>
     <li>Divide the batter between the prepared pans and put them in the preheated oven.</li>
-    <li>Bake for 30-35 minutes, until the cakes are lightly golden on top.</li>
+    <li>Bake for 30–35 minutes, until the cakes are lightly golden on top.</li>
     <li>Transfer to racks and let cool 10 minutes, then remove the parchment.</li>
     <li>Enjoy! 🤌</li>
   </ol>


### PR DESCRIPTION
En Dash should be used instead because it's used to represent a span or range of numbers, dates, or time.