### PR TITLE
fix: replace deprecated HTML tag

### DIFF
--- a/1-elements/07_band.html
+++ b/1-elements/07_band.html
@@ -22,5 +22,5 @@
     <li>Kill This Love - 2019 </li>
     <li>붐바야 (BOOMBAYAH) - 2016</li>
   </ol>
-  <marquee>Hwaiting! 🫰</marquee>
+  <canvas> Hwaiting! 🫰</canvas>
 </body>


### PR DESCRIPTION
## Description
In this PR, I omitted the deprecated `<marquee>` tag for the BlackPink code snippet and replaced it with the `<canvas>` tag. By making this change, Codedex users would be able to see the phrase, "Hwaiting!" in any browser. 

## Issue

Closes #45 

> [!NOTE]
> This is my first submission for the bug hunt challenge and Hacktoberfest! :) 
