### PR TITLE
fix: invalid image link

### DIFF
--- a/2-structure/14_top_8.html
+++ b/2-structure/14_top_8.html
@@ -40,44 +40,44 @@
     <div class="top-8-row">
       <div class="friend-card">
         <h2 class="friend-name">My Friend Tom</h2>
-        <img src="https://i.imgur.com/IZ3Vf9Nb.jpg" alt="Tom from MySpace">
+        <img src="https://i.imgur.com/d9USJcY.jpeg" alt="Tom from MySpace">
       </div>
 
       <div class="friend-card">
         <h2 class="friend-name">My Friend Tom</h2>
-        <img src="https://i.imgur.com/IZ3Vf9Nb.jpg" alt="Tom from MySpace">
+        <img src="https://i.imgur.com/d9USJcY.jpeg" alt="Tom from MySpace">
       </div>
 
       <div class="friend-card">
         <h2 class="friend-name">My Friend Tom</h2>
-        <img src="https://i.imgur.com/IZ3Vf9Nb.jpg" alt="Tom from MySpace">
+        <img src="https://i.imgur.com/d9USJcY.jpeg" alt="Tom from MySpace">
       </div>
 
       <div class="friend-card">
         <h2 class="friend-name">My Friend Tom</h2>
-        <img src="https://i.imgur.com/IZ3Vf9Nb.jpg" alt="Tom from MySpace">
+        <img src="https://i.imgur.com/d9USJcY.jpeg" alt="Tom from MySpace">
       </div>
     </div>
 
     <div class="top-8-row">
       <div class="friend-card">
         <h2 class="friend-name">My Friend Tom</h2>
-        <img src="https://i.imgur.com/IZ3Vf9Nb.jpg" alt="Tom from MySpace">
+        <img src="https://i.imgur.com/d9USJcY.jpeg" alt="Tom from MySpace">
       </div>
 
       <div class="friend-card">
         <h2 class="friend-name">My Friend Tom</h2>
-        <img src="https://i.imgur.com/IZ3Vf9Nb.jpg" alt="Tom from MySpace">
+        <img src="https://i.imgur.com/d9USJcY.jpeg" alt="Tom from MySpace">
       </div>
 
       <div class="friend-card">
         <h2 class="friend-name">My Friend Tom</h2>
-        <img src="https://i.imgur.com/IZ3Vf9Nb.jpg" alt="Tom from MySpace">
+        <img src="https://i.imgur.com/d9USJcY.jpeg" alt="Tom from MySpace">
       </div>
 
       <div class="friend-card">
         <h2 class="friend-name">My Friend Tom</h2>
-        <img src="https://i.imgur.com/IZ3Vf9Nb.jpg" alt="Tom from MySpace">
+        <img src="https://i.imgur.com/d9USJcY.jpeg" alt="Tom from MySpace">
       </div>
   </div>
 </body>


### PR DESCRIPTION
This PR replaces the link to the image, which doesn't seem to work anymore as it returns "Page not found" when accessing the image directly.